### PR TITLE
Work on a 4626 vault for MAHA that takes USDC as Collateral

### DIFF
--- a/contracts/interfaces/vault/IERC4626.sol
+++ b/contracts/interfaces/vault/IERC4626.sol
@@ -23,57 +23,6 @@ interface IERC4626 {
    */
 
   function asset() external view returns (address assetTokenAddress);
-  /**
-   * @dev Returns the total amount of the underlying asset that is “managed” by Vault.
-   *
-   * - SHOULD include any compounding that occurs from yield.
-   * - MUST be inclusive of any fees that are charged against assets in the Vault.
-   * - MUST NOT revert.
-   */
-  function totalAssets() external view returns (uint256 totalManagedAssets);
-  //   /**
-  //    * @dev Returns the amount of shares that the Vault would exchange for the amount of assets provided, in an ideal
-  //    * scenario where all the conditions are met.
-  //    *
-  //    * - MUST NOT be inclusive of any fees that are charged against assets in the Vault.
-  //    * - MUST NOT show any variations depending on the caller.
-  //    * - MUST NOT reflect slippage or other on-chain conditions, when performing the actual exchange.
-  //    * - MUST NOT revert.
-  //    *
-  //    * NOTE: This calculation MAY NOT reflect the “per-user” price-per-share, and instead should reflect the
-  //    * “average-user’s” price-per-share, meaning what the average user should expect to see when exchanging to and
-  //    * from.
-  //    */
-  function convertToShares(
-    uint256 assets
-  ) external view returns (uint256 shares);
-  //   /**
-  //    * @dev Returns the amount of assets that the Vault would exchange for the amount of shares provided, in an ideal
-  //    * scenario where all the conditions are met.
-  //    *
-  //    * - MUST NOT be inclusive of any fees that are charged against assets in the Vault.
-  //    * - MUST NOT show any variations depending on the caller.
-  //    * - MUST NOT reflect slippage or other on-chain conditions, when performing the actual exchange.
-  //    * - MUST NOT revert.
-  //    *
-  //    * NOTE: This calculation MAY NOT reflect the “per-user” price-per-share, and instead should reflect the
-  //    * “average-user’s” price-per-share, meaning what the average user should expect to see when exchanging to and
-  //    * from.
-  //    */
-  function convertToAssets(
-    uint256 shares
-  ) external view returns (uint256 assets);
-  //   /**
-  //    * @dev Returns the maximum amount of the underlying asset that can be deposited into the Vault for the receiver,
-  //    * through a deposit call.
-  //    *
-  //    * - MUST return a limited value if receiver is subject to some deposit limit.
-  //    * - MUST return 2 ** 256 - 1 if there is no limit on the maximum amount of assets that may be deposited.
-  //    * - MUST NOT revert.
-  //    */
-  //   function maxDeposit(
-  //     address receiver
-  //   ) external view returns (uint256 maxAssets);
   //   /**
   //    * @dev Allows an on-chain or off-chain user to simulate the effects of their deposit at the current block, given
   //    * current on-chain conditions.
@@ -89,9 +38,9 @@ interface IERC4626 {
   //    * NOTE: any unfavorable discrepancy between convertToShares and previewDeposit SHOULD be considered slippage in
   //    * share price or some other type of condition, meaning the depositor will lose assets by depositing.
   //    */
-  //   function previewDeposit(
-  //     uint256 assets
-  //   ) external view returns (uint256 shares);
+  function previewDeposit(
+    uint256 assets
+  ) external view returns (uint256 shares);
   /**
    * @dev Mints shares Vault shares to receiver by depositing exactly amount of underlying tokens.
    *
@@ -104,55 +53,6 @@ interface IERC4626 {
    * NOTE: most implementations will require pre-approval of the Vault with the Vault’s underlying asset token.
    */
   function deposit(uint256 assets, address receiver) external returns (uint256 shares);
-  //   /**
-  //    * @dev Returns the maximum amount of the Vault shares that can be minted for the receiver, through a mint call.
-  //    * - MUST return a limited value if receiver is subject to some mint limit.
-  //    * - MUST return 2 ** 256 - 1 if there is no limit on the maximum amount of shares that may be minted.
-  //    * - MUST NOT revert.
-  //    */
-  //   function maxMint(
-  //     address receiver
-  //   ) external view returns (uint256 maxShares);
-  //   /**
-  //    * @dev Allows an on-chain or off-chain user to simulate the effects of their mint at the current block, given
-  //    * current on-chain conditions.
-  //    *
-  //    * - MUST return as close to and no fewer than the exact amount of assets that would be deposited in a mint call
-  //    *   in the same transaction. I.e. mint should return the same or fewer assets as previewMint if called in the
-  //    *   same transaction.
-  //    * - MUST NOT account for mint limits like those returned from maxMint and should always act as though the mint
-  //    *   would be accepted, regardless if the user has enough tokens approved, etc.
-  //    * - MUST be inclusive of deposit fees. Integrators should be aware of the existence of deposit fees.
-  //    * - MUST NOT revert.
-  //    *
-  //    * NOTE: any unfavorable discrepancy between convertToAssets and previewMint SHOULD be considered slippage in
-  //    * share price or some other type of condition, meaning the depositor will lose assets by minting.
-  //    */
-  //   function previewMint(
-  //     uint256 shares
-  //   ) external view returns (uint256 assets);
-  /**
-   * @dev Mints exactly shares Vault shares to receiver by depositing amount of underlying tokens.
-   *
-   * - MUST emit the Deposit event.
-   * - MAY support an additional flow in which the underlying tokens are owned by the Vault contract before the mint
-   *   execution, and are accounted for during mint.
-   * - MUST revert if all of shares cannot be minted (due to deposit limit being reached, slippage, the user not
-   *   approving enough underlying tokens to the Vault contract, etc).
-   *
-   * NOTE: most implementations will require pre-approval of the Vault with the Vault’s underlying asset token.
-   */
-  function mint(uint256 shares, address receiver) external returns (uint256 assets);
-  //   /**
-  //    * @dev Returns the maximum amount of the underlying asset that can be withdrawn from the owner balance in the
-  //    * Vault, through a withdraw call.
-  //    *
-  //    * - MUST return a limited value if owner is subject to some withdrawal limit or timelock.
-  //    * - MUST NOT revert.
-  //    */
-  //   function maxWithdraw(
-  //     address owner
-  //   ) external view returns (uint256 maxAssets);
   //   /**
   //    * @dev Allows an on-chain or off-chain user to simulate the effects of their withdrawal at the current block,
   //    * given current on-chain conditions.
@@ -170,9 +70,9 @@ interface IERC4626 {
   //    * NOTE: any unfavorable discrepancy between convertToShares and previewWithdraw SHOULD be considered slippage in
   //    * share price or some other type of condition, meaning the depositor will lose assets by depositing.
   //    */
-  //   function previewWithdraw(
-  //     uint256 assets
-  //   ) external view returns (uint256 shares);
+  function previewWithdraw(
+    uint256 assets
+  ) external view returns (uint256 shares);
   //   /**
   //    * @dev Burns shares from owner and sends exactly assets of underlying tokens to receiver.
   //    *
@@ -186,47 +86,4 @@ interface IERC4626 {
   //    * Those methods should be performed separately.
   //    */
   function withdraw(uint256 assets, address receiver, address owner) external returns (uint256 shares);
-  //   /**
-  //    * @dev Returns the maximum amount of Vault shares that can be redeemed from the owner balance in the Vault,
-  //    * through a redeem call.
-  //    *
-  //    * - MUST return a limited value if owner is subject to some withdrawal limit or timelock.
-  //    * - MUST return balanceOf(owner) if owner is not subject to any withdrawal limit or timelock.
-  //    * - MUST NOT revert.
-  //    */
-  //   function maxRedeem(
-  //     address owner
-  //   ) external view returns (uint256 maxShares);
-  //   /**
-  //    * @dev Allows an on-chain or off-chain user to simulate the effects of their redeemption at the current block,
-  //    * given current on-chain conditions.
-  //    *
-  //    * - MUST return as close to and no more than the exact amount of assets that would be withdrawn in a redeem call
-  //    *   in the same transaction. I.e. redeem should return the same or more assets as previewRedeem if called in the
-  //    *   same transaction.
-  //    * - MUST NOT account for redemption limits like those returned from maxRedeem and should always act as though
-  // the
-  //    *   redemption would be accepted, regardless if the user has enough shares, etc.
-  //    * - MUST be inclusive of withdrawal fees. Integrators should be aware of the existence of withdrawal fees.
-  //    * - MUST NOT revert.
-  //    *
-  //    * NOTE: any unfavorable discrepancy between convertToAssets and previewRedeem SHOULD be considered slippage in
-  //    * share price or some other type of condition, meaning the depositor will lose assets by redeeming.
-  //    */
-  //   function previewRedeem(
-  //     uint256 shares
-  //   ) external view returns (uint256 assets);
-  //   /**
-  //    * @dev Burns exactly shares from owner and sends assets of underlying tokens to receiver.
-  //    *
-  //    * - MUST emit the Withdraw event.
-  //    * - MAY support an additional flow in which the underlying tokens are owned by the Vault contract before the
-  //    *   redeem execution, and are accounted for during redeem.
-  //    * - MUST revert if all of shares cannot be redeemed (due to withdrawal limit being reached, slippage, the owner
-  //    *   not having enough shares, etc).
-  //    *
-  //    * NOTE: some implementations will require pre-requesting to the Vault before a withdrawal may be performed.
-  //    * Those methods should be performed separately.
-  //    */
-  function redeem(uint256 shares, address receiver, address owner) external returns (uint256 assets);
 }

--- a/test/foundry/USDCVaultFork.sol
+++ b/test/foundry/USDCVaultFork.sol
@@ -47,35 +47,36 @@ contract USDCVaultFork is Test {
   function testInitValuesVault() external view {
     address vaultAddress = vault.asset();
     assertEq(vaultAddress, address(USDC));
-    assertEq(vault.totalAssets(), 0);
   }
 
   function testVaultDeposit() external {
-    // Need the whale USDC address
+    // Define the addresses for the whale and the recipient
     address USDCWHALE = 0x412Dd3F282b1FA20d3232d86aE060dEC644249f6;
     address bob = makeAddr("1");
+    uint256 depositAmount = 100_000_000; // USDC to deposit
+    // Start the prank for the whale (USDCWHALE)
     vm.startPrank(USDCWHALE);
-    // Approve Vault
-    USDC.approve(address(vault), 100_000_000);
-    // deposit 100 USDC in the vault
-    vault.deposit(100_000_000, bob);
+    // Approve Vault to transfer USDC
+    USDC.approve(address(vault), depositAmount);
+    // Perform the deposit of 100 million USDC into the vault for 'bob'
+    vault.deposit(depositAmount, bob);
     vm.stopPrank();
   }
 
-  function testVaultWithdraw() external {
+  function testWithdrawVault() external {
+    // Define the addresses for the whale and the recipient
     address USDCWHALE = 0x412Dd3F282b1FA20d3232d86aE060dEC644249f6;
     address bob = makeAddr("1");
-    uint256 depositAmount = 100_000_000;
-    uint256 withdrawAmount = 5_000_000;
+    address alice = makeAddr("2");
+    uint256 depositAmount = 100_000_000; // USDC to deposit
+    uint256 withdrawAmount = 50_000_000;
+    // Start the prank for the whale (USDCWHALE)
     vm.startPrank(USDCWHALE);
-    // Approve Vault
+    // Approve Vault to transfer USDC
     USDC.approve(address(vault), depositAmount);
-    // deposit 100 USDC in the vault
+    // Perform the deposit of 100 million USDC into the vault for 'bob'
     vault.deposit(depositAmount, bob);
-    vm.stopPrank();
-
-    vm.startPrank(bob);
-    vault.withdraw(withdrawAmount, address(this), bob);
+    vault.withdraw(withdrawAmount, alice, bob);
     vm.stopPrank();
   }
 }


### PR DESCRIPTION
This PR introduces the initial implementation of an ERC-4626 vault that accepts USDC as collateral and stakes it to mint sZAI. The vault utilizes the following flow: USDC → USDe → sUSDe → sZAI via the zapContract. The shares are denominated in ZAI/USD terms, and the asset value is designed to grow over time as more yield accumulates into sZAI.

Progress:

Deposit and Mint functionality have been implemented successfully.
Additional vault functions like withdraw and burn are left empty for now, pending further clarity on specific requirements and implementation details.

Next Steps:

Define and implement the withdraw and burn logic, ensuring sZAI is returned to users for manual withdrawal handling.
Finalize share calculation mechanisms and additional edge cases.
